### PR TITLE
Add Rust image resizer action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Build release
+        run: cargo build --release

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "image-resizer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive", "env"] }
+image = { version = "0.24", features = ["png", "jpeg", "gif", "bmp"] }
+log = "0.4"
+env_logger = "0.10"
+
+[dev-dependencies]
+tempfile = "3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM rust:1.75 as builder
+WORKDIR /workspace
+COPY . .
+RUN cargo build --release
+
+FROM debian:bullseye-slim
+COPY --from=builder /workspace/target/release/image-resizer /usr/local/bin/image-resizer
+ENTRYPOINT ["/usr/local/bin/image-resizer"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# resize-rs
+# Image Resizer Action
+
+This repository provides a simple GitHub Action written in Rust for resizing images to multiple square sizes. The action reads an image from your repository, resizes it to the requested widths and either crops or pads the image to a square.
+
+## Usage
+
+```yaml
+- uses: ./
+  with:
+    image-path: "assets/logo.png"
+    sizes: "64,128,256"
+    output-dir: "resized"
+    crop: true
+```
+
+## Example Workflow
+
+```yaml
+name: Build Icons
+on: [push]
+
+jobs:
+  resize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          image-path: "assets/logo.png"
+          sizes: "64,128,256"
+          output-dir: "icons"
+          crop: false
+```
+
+## Notes
+- The action compiles the Rust binary inside a Docker container and caches build artifacts automatically by GitHub Actions.
+- If you run the action frequently, consider using Rust caching strategies to speed up builds.

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,19 @@
+name: Image Resizer
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+inputs:
+  image-path:
+    description: 'Path to the source image'
+    required: true
+  sizes:
+    description: 'Comma-separated pixel widths'
+    required: true
+  output-dir:
+    description: 'Directory to write resized images'
+    required: true
+  crop:
+    description: 'Center crop instead of padding'
+    required: false
+    default: 'false'
+outputs: {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,161 @@
+use std::{fs, path::{Path, PathBuf}};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use image::{imageops, DynamicImage, GenericImageView, RgbImage, RgbaImage, Rgb, Rgba};
+use log::info;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    /// Path to the source image
+    #[arg(long, env = "INPUT_IMAGE_PATH")]
+    image_path: PathBuf,
+
+    /// Comma separated list of widths
+    #[arg(long, env = "INPUT_SIZES")]
+    sizes: String,
+
+    /// Output directory
+    #[arg(long, env = "INPUT_OUTPUT_DIR")]
+    output_dir: PathBuf,
+
+    /// Crop instead of pad
+    #[arg(long, env = "INPUT_CROP", default_value_t = false)]
+    crop: bool,
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+    let args = Args::parse();
+    run(args)
+}
+
+fn run(args: Args) -> Result<()> {
+    info!("Loading image..." );
+    let img = load_image(&args.image_path)?;
+    let sizes = parse_sizes(&args.sizes)?;
+    fs::create_dir_all(&args.output_dir)
+        .with_context(|| format!("creating output dir {}", args.output_dir.display()))?;
+
+    for size in sizes {
+        process_size(&img, &args.image_path, &args.output_dir, size, args.crop)?;
+    }
+    Ok(())
+}
+
+fn load_image(path: &Path) -> Result<DynamicImage> {
+    ensure_supported(path)?;
+    let img = image::open(path).with_context(|| format!("opening {}", path.display()))?;
+    Ok(img)
+}
+
+fn ensure_supported(path: &Path) -> Result<()> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .unwrap_or_default();
+    let supported = ["jpg", "jpeg", "png", "gif", "bmp"];
+    if !supported.contains(&ext.as_str()) {
+        anyhow::bail!("Unsupported image format: {}", ext);
+    }
+    if !path.exists() {
+        anyhow::bail!("Image path does not exist: {}", path.display());
+    }
+    Ok(())
+}
+
+fn parse_sizes(s: &str) -> Result<Vec<u32>> {
+    let mut out = Vec::new();
+    for part in s.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let value: u32 = part.parse().with_context(|| format!("invalid size '{}'", part))?;
+        if !out.contains(&value) {
+            out.push(value);
+        }
+    }
+    Ok(out)
+}
+
+fn process_size(img: &DynamicImage, src_path: &Path, out_dir: &Path, size: u32, crop: bool) -> Result<()> {
+    let (w, h) = img.dimensions();
+    let scale = size as f32 / w.min(h) as f32;
+    let new_w = (w as f32 * scale).round() as u32;
+    let new_h = (h as f32 * scale).round() as u32;
+    let resized = imageops::resize(img, new_w, new_h, imageops::FilterType::Lanczos3);
+
+    let final_img = if crop {
+        let x = if new_w > size { (new_w - size) / 2 } else { 0 };
+        let y = if new_h > size { (new_h - size) / 2 } else { 0 };
+        let cropped = imageops::crop_imm(&resized, x, y, size, size).to_image();
+        DynamicImage::ImageRgba8(cropped)
+    } else {
+        let mut canvas = if needs_alpha(src_path) {
+            DynamicImage::ImageRgba8(RgbaImage::from_pixel(size, size, Rgba([0, 0, 0, 0])))
+        } else {
+            DynamicImage::ImageRgb8(RgbImage::from_pixel(size, size, Rgb([255, 255, 255])))
+        };
+        let x = ((size as i64 - new_w as i64) / 2).max(0);
+        let y = ((size as i64 - new_h as i64) / 2).max(0);
+        imageops::overlay(&mut canvas, &resized, x, y);
+        canvas
+    };
+
+    let base = src_path.file_stem().and_then(|s| s.to_str()).unwrap_or("out");
+    let ext = src_path.extension().and_then(|s| s.to_str()).unwrap_or("png");
+    let out_path = out_dir.join(format!("{}-{}x{}.{}", base, size, size, ext));
+    final_img
+        .save(&out_path)
+        .with_context(|| format!("saving {}", out_path.display()))?;
+    info!(
+        "Resizing to {}x{} (crop={})... saved to {}",
+        size,
+        size,
+        crop,
+        out_path.display()
+    );
+    Ok(())
+}
+
+fn needs_alpha(path: &Path) -> bool {
+    match path.extension().and_then(|e| e.to_str()).map(|e| e.to_ascii_lowercase()) {
+        Some(ref ext) if ext == "png" || ext == "gif" => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_sizes_basic() {
+        let sizes = parse_sizes("64,128, 64").unwrap();
+        assert_eq!(sizes, vec![64, 128]);
+    }
+
+    #[test]
+    fn validate_supported() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("a.txt");
+        fs::write(&file, "hi").unwrap();
+        assert!(ensure_supported(&file).is_err());
+    }
+
+    #[test]
+    fn resize_basic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src_path = tmp.path().join("test.png");
+        DynamicImage::new_rgb8(8, 8).save(&src_path).unwrap();
+        let img = load_image(&src_path).unwrap();
+        let out_dir = tempfile::tempdir().unwrap();
+        process_size(&img, &src_path, out_dir.path(), 4, false).unwrap();
+        let out = out_dir.path().join("test-4x4.png");
+        assert!(out.exists());
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement image resizing CLI in Rust
- add Dockerfile and action metadata for a container action
- include CI workflow for tests and release build
- provide example usage in README
- fix Docker action entrypoint and remove binary fixture

## Testing
- `cargo test --quiet`
- `cargo build --release --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684879c1d3e88326af77549ce43f7932