### PR TITLE
Add CI checks and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,19 +2,25 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3
-
-      - name: Run tests
-        run: cargo test --verbose
-
-      - name: Build release
-        run: cargo build --release
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Format check
+        run: cargo fmt -- --check
+      - name: Lint
+        run: cargo clippy -- -D warnings
+      - name: Tests
+        run: cargo test -- --nocapture

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A fast, Rust-powered GitHub Action to batch-resize images by width while preserving aspect ratio.
 
-![GitHub Actions](https://github.com/elarsaks/resize-rs/workflows/CI/badge.svg)
+![CI Status](https://github.com/elarsaks/resize-rs/actions/workflows/ci.yml/badge.svg)
 
 ## 📦 Usage
 


### PR DESCRIPTION
## Summary
- update CI workflow to run rustfmt, clippy, and tests on Linux/macOS/Windows
- update badge in README to reflect workflow status

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6852eb38756883269fead7dfe6748204