### PR TITLE
Add extensive tests and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,28 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Tests
         run: cargo test -- --nocapture
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+          components: llvm-tools-preview
+      - name: Install grcov
+        run: cargo install grcov
+      - name: Run tests with coverage
+        env:
+          RUSTFLAGS: "-Zinstrument-coverage"
+          LLVM_PROFILE_FILE: "coverage-%p-%m.profraw"
+        run: cargo test -- --nocapture
+      - name: Generate coverage report
+        run: |
+          grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing -o lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,28 +24,39 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Tests
         run: cargo test -- --nocapture
-
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Rust (stable) with LLVM tools
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
-          profile: minimal
+          toolchain: stable
           override: true
+          profile: minimal
           components: llvm-tools-preview
+
       - name: Install grcov
         run: cargo install grcov
+
       - name: Run tests with coverage
         env:
-          RUSTFLAGS: "-Zinstrument-coverage"
+          RUSTFLAGS: "-C instrument-coverage"
           LLVM_PROFILE_FILE: "coverage-%p-%m.profraw"
-        run: cargo +nightly test -- --nocapture
+        run: cargo test -- --nocapture
 
       - name: Generate coverage report
         run: |
-          grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing -o lcov.info
+          grcov . \
+            --binary-path ./target/debug/ \
+            -s . \
+            -t lcov \
+            --branch \
+            --ignore-not-existing \
+            -o lcov.info
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
         env:
           RUSTFLAGS: "-Zinstrument-coverage"
           LLVM_PROFILE_FILE: "coverage-%p-%m.profraw"
-        run: cargo test -- --nocapture
+        run: cargo +nightly test -- --nocapture
+
       - name: Generate coverage report
         run: |
           grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing -o lcov.info

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > A fast, Rust-powered GitHub Action to batch-resize images by width while preserving aspect ratio.
 
 ![CI Status](https://github.com/elarsaks/resize-rs/actions/workflows/ci.yml/badge.svg)
+[![codecov](https://codecov.io/gh/elarsaks/resize-rs/branch/master/graph/badge.svg)](https://codecov.io/gh/elarsaks/resize-rs)
 
 ## 📦 Usage
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,4 +137,96 @@ mod tests {
         let out = out_dir.path().join("test-4.png");
         assert!(out.exists());
     }
+
+    #[test]
+    fn parse_sizes_invalid() {
+        assert!(parse_sizes("abc").is_err());
+        assert!(parse_sizes("64,xyz").is_err());
+    }
+
+    #[test]
+    fn parse_sizes_empty() {
+        let v = parse_sizes("").expect("empty string ok");
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn unsupported_extension() {
+        let dir = tempfile::tempdir().expect("create dir");
+        let file = dir.path().join("img.txt");
+        fs::write(&file, "hi").expect("write temp file");
+        assert!(ensure_supported(&file).is_err());
+    }
+
+    #[test]
+    fn nonexistent_file() {
+        let path = PathBuf::from("/no/such/file.png");
+        assert!(ensure_supported(&path).is_err());
+    }
+
+    #[test]
+    fn downscale_and_upscale() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let src_path = tmp.path().join("img.png");
+        DynamicImage::new_rgb8(10, 10).save(&src_path).expect("save source image");
+        let img = load_image(&src_path).expect("load image");
+
+        // downscale
+        let out_dir = tempfile::tempdir().expect("create temp dir");
+        process_size(&img, &src_path, out_dir.path(), 5).expect("downscale image");
+        let resized = image::open(out_dir.path().join("img-5.png")).expect("open resized");
+        assert_eq!(resized.dimensions(), (5, 5));
+
+        // upscale
+        let out_dir2 = tempfile::tempdir().expect("create temp dir");
+        process_size(&img, &src_path, out_dir2.path(), 20).expect("upscale image");
+        let resized2 = image::open(out_dir2.path().join("img-20.png")).expect("open resized");
+        assert_eq!(resized2.dimensions(), (20, 20));
+    }
+
+    #[test]
+    fn different_filters() {
+        use image::imageops::FilterType::*;
+        let img = DynamicImage::ImageRgb8(image::ImageBuffer::from_fn(5, 5, |x, y| {
+            image::Rgb([x as u8, y as u8, (x + y) as u8])
+        }));
+        let n = image::imageops::resize(&img, 10, 10, Nearest);
+        let b = image::imageops::resize(&img, 10, 10, Triangle);
+        let l = image::imageops::resize(&img, 10, 10, Lanczos3);
+        assert_eq!(n.dimensions(), (10, 10));
+        assert_eq!(b.dimensions(), (10, 10));
+        assert_eq!(l.dimensions(), (10, 10));
+        // Ensure filters actually differ
+        assert_ne!(n.as_raw(), b.as_raw());
+    }
+
+    #[test]
+    fn pixel_formats() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let paths = [tmp.path().join("a.png"), tmp.path().join("b.png"), tmp.path().join("c.png")];
+        DynamicImage::new_rgba8(8, 8).save(&paths[0]).expect("save rgba8");
+        DynamicImage::new_rgb8(8, 8).save(&paths[1]).expect("save rgb8");
+        DynamicImage::new_luma8(8, 8).save(&paths[2]).expect("save luma8");
+
+        for p in &paths {
+            let img = load_image(p).expect("load image");
+            let out_dir = tempfile::tempdir().expect("create temp dir");
+            process_size(&img, p, out_dir.path(), 4).expect("resize image");
+            let stem = p.file_stem().and_then(|s| s.to_str()).expect("file stem");
+            let out = out_dir.path().join(format!("{}-4.png", stem));
+            assert!(out.exists());
+        }
+    }
+
+    #[test]
+    fn large_image_and_aspect_ratio() {
+        let tmp = tempfile::tempdir().expect("create temp dir");
+        let src_path = tmp.path().join("large.png");
+        DynamicImage::new_rgb8(4096, 512).save(&src_path).expect("save large image");
+        let img = load_image(&src_path).expect("load image");
+        let out_dir = tempfile::tempdir().expect("create temp dir");
+        process_size(&img, &src_path, out_dir.path(), 1024).expect("resize image");
+        let out = image::open(out_dir.path().join("large-1024.png")).expect("open resized");
+        assert_eq!(out.dimensions(), (1024, 128));
+    }
 }


### PR DESCRIPTION
## Summary
- add new tests for parsing, resizing, pixel formats and edge cases
- integrate grcov-based coverage reporting in CI
- add Codecov badge to README
- replace unwrap() with expect() in tests as requested

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_6852eeaeb05083268692a3e3d0b179a1